### PR TITLE
Avoid excessive list comparations

### DIFF
--- a/gui_logic.py
+++ b/gui_logic.py
@@ -383,7 +383,7 @@ class GuiProgram(Ui_Dialog):
     # Основная программа - (3) Разница пустого и полезного сигнала
     def signal_difference(self):
         # Сигналов нет - прекращаем
-        if self.data_signals.empty_gamma == [] or self.data_signals.signal_gamma == []:
+        if not self.data_signals.empty_gamma or not self.data_signals.signal_gamma:
             return
 
         # Вычитаем отсчеты сигнала с ошибкой и без
@@ -531,7 +531,7 @@ class GuiProgram(Ui_Dialog):
     # Кнопка сохранения таблицы
     def saving_data(self):
         # Проверка, что данные для сохранения есть
-        if self.data_signals.frequency_peak == [] or self.data_signals.gamma_peak == []:
+        if not self.data_signals.frequency_peak or not self.data_signals.gamma_peak:
             QMessageBox.about(None, "Ошибка данных", "Нет данных для сохранения.")
             return
 


### PR DESCRIPTION
The `__bool__` function of a list returns whether the list contains something, i.e., `False` if the list _is empty_ or `True` otherwise.

From [Boolean operations](https://docs.python.org/3/reference/expressions.html#boolean-operations):

> In the context of Boolean operations, and also when expressions are used by control flow statements, the following values are interpreted as _false_: `False`, `None`, numeric zero of all types, and empty strings and containers (including strings, tuples, lists, dictionaries, sets and frozensets). All other values are interpreted as _true_.