### PR TITLE
Make messages look more severe

### DIFF
--- a/gui_logic.py
+++ b/gui_logic.py
@@ -64,12 +64,12 @@ def frequency_input_check(frequency, field_name):
         frequency = float(frequency)
 
     except ValueError:
-        QMessageBox.about(None, "Ошибка ввода", "Введите число в поле '" + field_name + "'.")
+        QMessageBox.warning(None, "Ошибка ввода", "Введите число в поле '" + field_name + "'.")
         return False
 
     # Проверка положительности
     if frequency < 0:
-        QMessageBox.about(None, "Ошибка ввода", "Введите положительное число в поле '" + field_name + "'.")
+        QMessageBox.warning(None, "Ошибка ввода", "Введите положительное число в поле '" + field_name + "'.")
         return False
 
     return True
@@ -81,7 +81,7 @@ def window_width_input_check(window_width):
         window_width = float(window_width)
 
     except ValueError:
-        QMessageBox.about(None, "Ошибка ввода", "Введите число в поле 'ширина окна просмотра'.")
+        QMessageBox.warning(None, "Ошибка ввода", "Введите число в поле 'ширина окна просмотра'.")
         return False
 
     # Проверка положительности
@@ -98,12 +98,12 @@ def percentage_check(percentage):
         percentage = float(percentage)
 
     except ValueError:
-        QMessageBox.about(None, "Ошибка ввода", "Введите число в поле порога.")
+        QMessageBox.warning(None, "Ошибка ввода", "Введите число в поле порога.")
         return False
 
     # Проверка
     if percentage < 0 or percentage > 100:
-        QMessageBox.about(None, "Ошибка ввода", "Пороговое значение должно быть от 0 до 100.")
+        QMessageBox.warning(None, "Ошибка ввода", "Пороговое значение должно быть от 0 до 100.")
         return False
 
     return True
@@ -292,7 +292,7 @@ class GuiProgram(Ui_Dialog):
 
             # Проверка на правильность границ
             if end_frequency < start_frequency:
-                QMessageBox.about(None, "Ошибка ввода", "Частота 'от' больше 'до', в фильтре чтения. ")
+                QMessageBox.warning(self, "Ошибка ввода", "Частота 'от' больше 'до', в фильтре чтения. ")
                 return
 
             # Парс данных в заданных частотах
@@ -358,7 +358,7 @@ class GuiProgram(Ui_Dialog):
 
             # Проверка на правильность границ
             if end_frequency < start_frequency:
-                QMessageBox.about(None, "Ошибка ввода", "Частота 'от' больше 'до', в фильтре чтения. ")
+                QMessageBox.warning(self, "Ошибка ввода", "Частота 'от' больше 'до', в фильтре чтения. ")
                 return
 
             # Парс данных в заданных частотах
@@ -532,7 +532,7 @@ class GuiProgram(Ui_Dialog):
     def saving_data(self):
         # Проверка, что данные для сохранения есть
         if self.data_signals.frequency_peak == [] or self.data_signals.gamma_peak == []:
-            QMessageBox.about(None, "Ошибка данных", "Нет данных для сохранения.")
+            QMessageBox.warning(self, "Ошибка данных", "Нет данных для сохранения.")
             return
 
         # Рек-мое название файла


### PR DESCRIPTION
`QMessageBox` [provides styled messages](https://doc.qt.io/qt-5/qmessagebox.html#static-public-members) for various occasions. Pick something more suitable than just `about`. That should make the messages modal on macOS.

And specify parents where possible. See the [docs](https://doc.qt.io/qt-5/qdialog.html) on it:

> A dialog is always a top-level widget, but if it has a parent, its default location is centered on top of the parent's top-level widget (if it is not top-level itself). It will also share the parent's taskbar entry.